### PR TITLE
support sublists & sentences splitted into multiple lines

### DIFF
--- a/benches/transforming-benchmark.rs
+++ b/benches/transforming-benchmark.rs
@@ -1,17 +1,12 @@
-use doxygen_rs::{transform};
-use criterion::{
-    criterion_group,
-    criterion_main,
-    Criterion,
-};
+use criterion::{criterion_group, criterion_main, Criterion};
+use doxygen_rs::transform;
 
 const CTRU_SYS_BINDINGS: &str = include_str!("../assets/tests/ctru-sys-bindings.rs");
 
 fn transform_bindgen_benchmark(c: &mut Criterion) {
-    c.bench_function(
-        "bindgen transform",
-        |b| b.iter(|| transform(CTRU_SYS_BINDINGS))
-    );
+    c.bench_function("bindgen transform", |b| {
+        b.iter(|| transform(CTRU_SYS_BINDINGS))
+    });
 }
 
 criterion_group!(benches, transform_bindgen_benchmark);

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -3,18 +3,18 @@
 //! **The functions and structs here should _not_ be considered stable**
 
 use std::fmt::{Display, Formatter};
-use crate::parser::Value;
+use crate::parser::{Value, NestedString};
 use crate::utils::NotationMatching;
 
 /// Represents a parsed Doxygen comment.
 #[derive(Clone, Debug)]
 pub struct ParsedDoxygen {
     /// _Title_ of the item being documented
-    pub title: Option<String>,
+    pub title: Option<NestedString>,
     /// A _brief_ introduction to the item being documented.
-    pub brief: Option<String>,
+    pub brief: Option<NestedString>,
     /// A _description_ of the item being documented.
-    pub description: Option<String>,
+    pub description: Option<Vec<NestedString>>,
     /// List of _warnings_ of the item being documented.
     pub warnings: Option<Vec<Warning>>,
     /// List of _notes_ of the item being documented.
@@ -24,7 +24,7 @@ pub struct ParsedDoxygen {
     /// Data about the _deprecation_ status of the item being documented.
     pub deprecated: Option<Deprecated>,
     /// List of _To Do_s of the item being documented.
-    pub todos: Option<Vec<String>>,
+    pub todos: Option<Vec<NestedString>>,
     /// Description of the values being _returned_
     pub returns: Option<Vec<Return>>,
     /// Possible _return values_ of the item being documented
@@ -39,7 +39,7 @@ pub struct Param {
     /// The _direction_ of the argument. [Check Doxygen docs for more info](https://www.doxygen.nl/manual/commands.html#cmdparam)
     pub direction: Option<Direction>,
     /// The _description_ of the argument.
-    pub description: Option<String>,
+    pub description: Option<NestedString>,
 }
 
 /// Represents the _deprecation_ status of an item.
@@ -48,24 +48,24 @@ pub struct Deprecated {
     /// Whether _is deprecated_ or not
     pub is_deprecated: bool,
     /// The message left with the deprecation status
-    pub message: Option<String>,
+    pub message: Option<NestedString>,
 }
 
 /// Represents a _note_
 #[derive(Clone, Debug)]
-pub struct Note(pub String);
+pub struct Note(pub NestedString);
 
 /// Represents a _warning_
 #[derive(Clone, Debug)]
-pub struct Warning(pub String);
+pub struct Warning(pub NestedString);
 
 /// Represents a _return_
 #[derive(Clone, Debug)]
-pub struct Return(pub String);
+pub struct Return(pub NestedString);
 
 /// Represents a _return_ value
 #[derive(Clone, Debug)]
-pub struct ReturnValue(pub String);
+pub struct ReturnValue(pub NestedString);
 
 /// The _direction_ of an argument. [Check Doxygen docs for more info](https://www.doxygen.nl/manual/commands.html#cmdparam)
 #[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq)]
@@ -135,13 +135,13 @@ pub fn generate_ast(input: Vec<Value>) -> ParsedDoxygen {
 
     for value in input {
         match value {
-            Value::Notation(notation, content) => {
+            Value::Notation(notation, mut content) => {
                 if notation.starts_with_notation("brief") {
                     brief = Some(content);
                 } else if notation.starts_with_notation("deprecated") {
                     deprecated = Some(Deprecated {
                         is_deprecated: true,
-                        message: if content.is_empty() { None } else { Some(content) },
+                        message: if content.top.is_empty() { None } else { Some(content) },
                     });
                 } else if notation.starts_with_notation("details") {
                     currently_saving_paragraph = true;
@@ -168,17 +168,17 @@ pub fn generate_ast(input: Vec<Value>) -> ParsedDoxygen {
                     };
 
                     let arg_name = {
-                        let split = content.split_whitespace().map(|v| v.to_string()).collect::<Vec<String>>();
+                        let split = content.top.split_whitespace().map(|v| v.to_string()).collect::<Vec<String>>();
                         split.first().unwrap().to_owned()
                     };
 
                     let description = {
-                        let split = content.split_whitespace().map(|v| v.to_string()).collect::<Vec<String>>();
-                        let description = split[1..].to_vec().join(" ");
-                        if description.is_empty() {
+                        let split: Vec<&str> = content.top.splitn(2, char::is_whitespace).collect();
+                        content.top = split[1].to_string();
+                        if content.top.is_empty() {
                             None
                         } else {
-                            Some(description)
+                            Some(content)
                         }
                     };
 
@@ -202,7 +202,7 @@ pub fn generate_ast(input: Vec<Value>) -> ParsedDoxygen {
             Value::Text(content) => {
                 if currently_saving_paragraph {
                     paragraph_buffer.push(content);
-                } else if content.trim() != "*" && content.trim() != "*/" && content.trim() != "**" {
+                } else if content.to_string().trim() != "*" && content.to_string().trim() != "*/" && content.to_string().trim() != "**" {
                     description.push(content);
                 }
             }
@@ -211,7 +211,7 @@ pub fn generate_ast(input: Vec<Value>) -> ParsedDoxygen {
                     if let Some(move_buffer_to) = move_buffer_to.clone() {
                         match move_buffer_to {
                             MoveBufferTo::Description => description.append(&mut paragraph_buffer.clone()),
-                            MoveBufferTo::ToDo => todos.push(paragraph_buffer.join("\n")),
+                            MoveBufferTo::ToDo => todos.append(&mut paragraph_buffer.clone()),
                         }
                     }
                     currently_saving_paragraph = false;
@@ -220,11 +220,12 @@ pub fn generate_ast(input: Vec<Value>) -> ParsedDoxygen {
                 }
             }
             Value::Unknown => {}
+            Value::Continuation(_, _, _) => unreachable!(),//only for parser internal use 
         }
     }
 
     // TODO: Improve this
-    let description = (!description.is_empty()).then(|| description.join("\n"));
+    let description = (!description.is_empty()).then_some(description);
     let returns = (!returns.is_empty()).then_some(returns);
     let todos = (!todos.is_empty()).then_some(todos);
     let warnings = (!warnings.is_empty()).then_some(warnings);
@@ -258,13 +259,13 @@ mod tests {
         let first_param = doxygen.params.as_ref().unwrap();
         let first_param = first_param.get(0).unwrap();
         assert_eq!(first_param.arg_name, "random");
-        assert_eq!(first_param.description, Some("Random thing lmao".to_string()));
+        assert_eq!(first_param.description, Some(NestedString::new("Random thing lmao".to_string())));
         assert_eq!(first_param.direction, None);
 
         let second_param = doxygen.params.as_ref().unwrap();
         let second_param = second_param.get(1).unwrap();
         assert_eq!(second_param.arg_name, "goes_in");
-        assert_eq!(second_param.description, Some("This goes in lmao".to_string()));
+        assert_eq!(second_param.description, Some(NestedString::new("This goes in lmao".to_string())));
         assert_eq!(second_param.direction, Some(Direction::In));
     }
 
@@ -272,23 +273,56 @@ mod tests {
     fn parses_brief() {
         let doxygen = generate_ast(parser::parse_comment("@brief This function does things"));
 
-        assert_eq!(doxygen.brief, Some("This function does things".to_string()));
+        assert_eq!(doxygen.brief, Some(NestedString::new("This function does things".to_string())));
     }
 
     #[test]
     fn parses_description() {
         let doxygen = generate_ast(parser::parse_comment("@brief This is a function\n\nThis is the description of the thing.\nYou should do things with this function.\nOr not, I don't really care."));
 
-        assert_eq!(doxygen.description, Some("This is the description of the thing.\nYou should do things with this function.\nOr not, I don't really care.".to_string()))
+        assert_eq!(doxygen.description, Some(vec![NestedString::new("This is the description of the thing.".to_string()), NestedString::new("You should do things with this function.".to_string()),NestedString::new("Or not, I don't really care.".to_string())]))
     }
+    #[test]
+    fn parses_multiline_simple() {
+        let doxygen = generate_ast(parser::parse_comment("@brief This is a function\n\nThis is the description of the thing.\n    You should do things with this function.\n    Or not, I don't really care."));
 
+        assert_eq!(doxygen.description, Some(vec![NestedString::new("This is the description of the thing. You should do things with this function. Or not, I don't really care.".to_string())]))
+    }
+    #[test]
+    fn parses_multiline_sublist() {
+        let doxygen = generate_ast(parser::parse_comment("@brief This is a function\n\nThis is the description of the thing.\n    - You should do things with this function.\n    - Or not, I don't really care."));
+
+        assert_eq!(doxygen.description, Some(
+            vec![
+                NestedString{
+                    top:"This is the description of the thing.".to_string(),
+                    sub: vec![
+                        NestedString::new("You should do things with this function.".to_string()),
+                        NestedString::new("Or not, I don't really care.".to_string())]}]))
+    }
+    #[test]
+    fn parses_multiline_sublist_complex() {
+        let doxygen = generate_ast(parser::parse_comment("@brief This is a function\n\nThis is the description of the thing.\n    - You should do things with:\n      - this function.\n      - that function.\n        (with long description)\n    - Or not, I don't really care."));
+
+        assert_eq!(doxygen.description, Some(
+            vec![
+                NestedString{
+                    top:"This is the description of the thing.".to_string(),
+                    sub: vec![
+                        NestedString{
+                            top:"You should do things with:".to_string(),
+                            sub: vec![
+                                NestedString::new("this function.".to_string()),
+                                NestedString::new("that function. (with long description)".to_string())]},
+                        NestedString::new("Or not, I don't really care.".to_string())]}]));
+    }
     #[test]
     fn parses_deprecated() {
         let doxygen = generate_ast(parser::parse_comment("@deprecated This function is pure spaghetti lmao\n\n@brief Creates a single spaghetti"));
 
         let deprecated = doxygen.deprecated.unwrap();
         assert_eq!(deprecated.is_deprecated, true);
-        assert_eq!(deprecated.message, Some("This function is pure spaghetti lmao".to_string()));
+        assert_eq!(deprecated.message, Some(NestedString::new("This function is pure spaghetti lmao".to_string())));
     }
 
     #[test]
@@ -296,7 +330,7 @@ mod tests {
         let doxygen = generate_ast(parser::parse_comment("@brief This does things\n\n@details This does _advanced_ things\nAnd the _advanced_ things are not easy"));
 
         let description = doxygen.description.unwrap();
-        assert_eq!(description, "This does _advanced_ things\nAnd the _advanced_ things are not easy");
+        assert_eq!(description, vec![NestedString::new("This does _advanced_ things".to_string()), NestedString::new("And the _advanced_ things are not easy".to_string())]);
     }
 
     #[test]
@@ -304,7 +338,7 @@ mod tests {
         let doxygen = generate_ast(parser::parse_comment("@brief This is WIP\n\n@todo Fix the bug where the C: drive is deleted"));
 
         let todos = doxygen.todos.unwrap();
-        assert_eq!(todos.get(0).unwrap(), "Fix the bug where the C: drive is deleted");
+        assert_eq!(todos.get(0).unwrap().clone(), NestedString::new("Fix the bug where the C: drive is deleted".to_string()));
     }
 
     #[test]
@@ -313,10 +347,10 @@ mod tests {
 
         let first_param = doxygen.params.unwrap();
         let first_param = first_param.first().unwrap();
-        assert_eq!(doxygen.brief, Some("Creates a new dog.".to_string()));
-        assert_eq!(doxygen.description, Some("Creates a new Dog named `_name` with half of its maximum energy.".to_string()));
+        assert_eq!(doxygen.brief, Some(NestedString::new("Creates a new dog.".to_string())));
+        assert_eq!(doxygen.description, Some(vec![NestedString::new("Creates a new Dog named `_name` with half of its maximum energy.".to_string())]));
         assert_eq!(first_param.arg_name, "_name".to_string());
-        assert_eq!(first_param.description, Some("The dog's name.".to_string()));
+        assert_eq!(first_param.description, Some(NestedString::new("The dog's name.".to_string())));
         assert_eq!(first_param.direction, None);
     }
 }

--- a/src/generator/mod.rs
+++ b/src/generator/mod.rs
@@ -33,19 +33,21 @@ pub fn generate_rustdoc(doxygen: ParsedDoxygen) -> String {
     }
 
     if let Some(brief) = doxygen.brief {
-        rustdoc += brief.as_str();
+        rustdoc += &brief.to_string();
         rustdoc += "\n\n";
     }
 
     if let Some(description) = doxygen.description {
-        rustdoc += description.replace("< ", "").as_str();
-        rustdoc += "\n\n";
+        for desc in description {
+            rustdoc += format!("{}\n", desc).as_str();
+        }
+        rustdoc += "\n";
     }
 
     if let Some(warnings) = doxygen.warnings {
         rustdoc += "**Warning!**\n\n";
         for warning in warnings {
-            rustdoc += format!("* {}\n", warning.0).as_str();
+            rustdoc += format!("{:1}\n", warning.0).as_str();
         }
         rustdoc += "\n"
     }
@@ -53,7 +55,7 @@ pub fn generate_rustdoc(doxygen: ParsedDoxygen) -> String {
     if let Some(returns) = doxygen.returns {
         rustdoc += "Returns:\n\n";
         for return_val in returns {
-            rustdoc += format!("* {}\n", return_val.0).as_str()
+            rustdoc += format!("{:1}\n", return_val.0).as_str()
         }
         rustdoc += "\n";
     }
@@ -61,14 +63,16 @@ pub fn generate_rustdoc(doxygen: ParsedDoxygen) -> String {
     if let Some(params) = doxygen.params {
         rustdoc += "# Arguments\n\n";
         for param in params {
-            if let Some(description) = param.description {
-                rustdoc += format!("* `{}` - {}", param.arg_name, description).as_str();
-            } else {
-                rustdoc += format!("* `{}`", param.arg_name).as_str();
-            }
-
+            let mut dir=String::new();
             if let Some(direction) = param.direction {
-                rustdoc += format!(" [Direction: {}]", direction).as_str();
+                dir+=format!(" [Direction: {}] ", direction.clone()).as_str()
+            }
+            else{dir+=" "};
+
+            if let Some(description) = param.description {
+                rustdoc += format!("* `{}` -{}{:#1}", param.arg_name, dir, description).as_str();
+            } else {
+                rustdoc += format!("* `{}` -{}", param.arg_name, dir).as_str();
             }
 
             rustdoc += "\n";
@@ -80,7 +84,7 @@ pub fn generate_rustdoc(doxygen: ParsedDoxygen) -> String {
     if let Some(return_values) = doxygen.return_values {
         rustdoc += "# Return values\n";
         for return_val in return_values {
-            rustdoc += format!("* {}\n", return_val.0).as_str();
+            rustdoc += format!("{:1}\n", return_val.0).as_str();
         }
         rustdoc += "\n"
     }
@@ -88,7 +92,7 @@ pub fn generate_rustdoc(doxygen: ParsedDoxygen) -> String {
     if let Some(notes) = doxygen.notes {
         rustdoc += "# Notes\n\n";
         for note in notes {
-            rustdoc += format!("* {}\n", note.0).as_str();
+            rustdoc += format!("{:1}\n", note.0).as_str();
         }
         rustdoc += "\n"
     }
@@ -96,7 +100,7 @@ pub fn generate_rustdoc(doxygen: ParsedDoxygen) -> String {
     if let Some(todos) = doxygen.todos {
         rustdoc += "# To Do\n\n";
         for todo in todos {
-            rustdoc += format!("* {}", todo).as_str();
+            rustdoc += format!("{:1}", todo).as_str();
         }
 
         rustdoc += "\n";

--- a/src/generator/mod.rs
+++ b/src/generator/mod.rs
@@ -63,11 +63,12 @@ pub fn generate_rustdoc(doxygen: ParsedDoxygen) -> String {
     if let Some(params) = doxygen.params {
         rustdoc += "# Arguments\n\n";
         for param in params {
-            let mut dir=String::new();
+            let mut dir = String::new();
             if let Some(direction) = param.direction {
-                dir+=format!(" [Direction: {}] ", direction.clone()).as_str()
-            }
-            else{dir+=" "};
+                dir += format!(" [Direction: {}] ", direction.clone()).as_str()
+            } else {
+                dir += " "
+            };
 
             if let Some(description) = param.description {
                 rustdoc += format!("* `{}` -{}{:#1}", param.arg_name, dir, description).as_str();

--- a/src/generator/mod.rs
+++ b/src/generator/mod.rs
@@ -39,7 +39,7 @@ pub fn generate_rustdoc(doxygen: ParsedDoxygen) -> String {
 
     if let Some(description) = doxygen.description {
         for desc in description {
-            rustdoc += format!("{}\n", desc).as_str();
+            rustdoc += format!("{}\n", desc).replace("< ", "").as_str();
         }
         rustdoc += "\n";
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,9 +34,9 @@
 
 use crate::parser::StringType;
 
-pub mod parser;
 pub mod ast;
 pub mod generator;
+pub mod parser;
 mod utils;
 
 /// Transforms raw Doxygen comments to raw Rustdoc comments
@@ -64,9 +64,12 @@ pub fn transform_bindgen(input: &str) -> String {
             StringType::Parsed(data) => {
                 let ast = ast::generate_ast(data);
                 let rustdoc = generator::generate_rustdoc(ast);
-                let bindgen_doc = rustdoc.lines().map(|v| format!("#[doc = \"{}\"]\n", v.trim())).collect::<String>();
+                let bindgen_doc = rustdoc
+                    .lines()
+                    .map(|v| format!("#[doc = \"{}\"]\n", v.trim()))
+                    .collect::<String>();
                 file_data.push(bindgen_doc);
-            },
+            }
             StringType::Raw(raw) => file_data.push(raw),
         }
     }
@@ -122,10 +125,7 @@ Returns:
     * and nested sublist
 
 "#;
-        assert_eq!(
-            EXPECTED,
-            transform(INPUT).as_str(),
-        );
+        assert_eq!(EXPECTED, transform(INPUT).as_str(),);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,10 +84,18 @@ mod tests {
         const INPUT: &str = r#"
 @brief Creates a new dog.
 
-Creates a new Dog named `_name` with half of its maximum energy.
+Creates a new Dog named `_name` with half
+    of its maximum
+    energy.
 
-@param _name The dog's name.
-@param[in] _test Test for In
+
+@param _name The dog's name. Ignored when:
+    - _test input null
+    - random_dog cfg option set 
+@param[in] _test Test for In,
+    also testing longer param description
+    - also param sublist
+      - and nested sublist
 
 @deprecated
 
@@ -106,8 +114,12 @@ Returns:
 
 # Arguments
 
-* `_name` - The dog's name.
-* `_test` - Test for In [Direction: In]
+* `_name` - The dog's name. Ignored when:
+  * _test input null
+  * random_dog cfg option set 
+* `_test` - [Direction: In] Test for In, also testing longer param description
+  * also param sublist
+    * and nested sublist
 
 "#;
         assert_eq!(

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -113,19 +113,19 @@ fn parse_single_line(line: &str) -> Value {
     let mut chars_to_skip = 0;
     let mut sublist = false;
     for ch in line.chars() {
-        if ch.is_whitespace() && !sublist {
+        if ch.is_whitespace() {
             leading_whitespaces += 1;
-        } else if ch.is_whitespace() {
-        }
-        //just skip whitespaces after sublist mark
-        else if ch == '-' || ch == '*' || ch == '+' {
+        } else if ch == '-' || ch == '*' || ch == '+' {
             sublist = true;
+            chars_to_skip = leading_whitespaces + 1;
+            break;
         } else {
+            chars_to_skip = leading_whitespaces;
             break;
         };
-        chars_to_skip += 1;
     }
-    line.drain(..chars_to_skip);
+    line.drain(..chars_to_skip); //remove leading whitespaces and sublist mark
+    line = line.trim_start().to_string(); //remove leading whitespaces after sublist mark
     if let Some(notation) = line.contains_any_notation() {
         let split = line.split_whitespace().collect::<Vec<&str>>();
         Value::Notation(notation, NestedString::new(split[1..].to_vec().join(" ")))

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -95,7 +95,7 @@ pub enum Value {
     Text(NestedString),
     /// Double new-line, or any other separator
     Separator,
-    /// indented Text- probably continuation of previous line; [`String`]- line text stripped of leading whitespaces & sublist characters as '-','*'; [`usize`] - number of leading whitespaces; [`bool`]- sublist char present? 
+    /// indented Text- probably continuation of previous line; [`String`]- line text stripped of leading whitespaces & sublist characters as '-','*'and '+'; [`usize`] - number of leading whitespaces; [`bool`]- sublist char present? 
     Continuation(String, usize, bool),
     /// Unknown value
     Unknown,
@@ -108,10 +108,10 @@ fn parse_single_line(line: &str) -> Value {
     let mut sublist = false;
     for ch in line.chars()
     {
-        if ch.is_whitespace() && !sublist   { leading_whitespaces+=1; }
-        else if ch.is_whitespace()          { }//just skip whitespaces after sublist mark
-        else if ch == '-' || ch == '*'      { sublist = true; }
-        else                                { break; };
+        if ch.is_whitespace() && !sublist           { leading_whitespaces+=1; }
+        else if ch.is_whitespace()                  { }//just skip whitespaces after sublist mark
+        else if ch == '-' || ch == '*' || ch == '+' { sublist = true; }
+        else                                        { break; };
         chars_to_skip+=1;
     }
     line.drain(..chars_to_skip);

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2,85 +2,91 @@
 //!
 //! **The functions and structs here should _not_ be considered stable**
 
-use std::fmt::{Display};
+use std::fmt::Display;
 
 use crate::utils::NotationMatching;
 
 mod preprocessor;
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub struct NestedString
-{
+pub struct NestedString {
     pub top: String,
-    pub sub: Vec<NestedString>
+    pub sub: Vec<NestedString>,
 }
-impl Default for NestedString
-{
+impl Default for NestedString {
     fn default() -> Self {
-        Self { top: Default::default(), sub: Default::default() }
+        Self {
+            top: Default::default(),
+            sub: Default::default(),
+        }
     }
 }
-impl NestedString
-{
-    pub fn new(top: String) -> Self { Self { top, sub:vec![] } }
-
-    pub fn to_string(&self)->String
-    {
-        format!("{}",self)
+impl NestedString {
+    pub fn new(top: String) -> Self {
+        Self { top, sub: vec![] }
     }
 
-    pub fn modify_sub(mut self, nesting_depth : usize, sublist : bool, line: String)->NestedString
-    {
-        let mut refs_vec=vec![self];
-        for _ in 1..nesting_depth
-        {
-            let mut high=refs_vec.pop().unwrap();//unwrap will not panic, couse refs_vec has initial len>0 and then len is inreasing
-            let low= high.sub.pop();
-            refs_vec.push(high);//return to ref_vec what we has taken in this iteration(stripped of last element of sub)
+    pub fn to_string(&self) -> String {
+        format!("{}", self)
+    }
+
+    pub fn modify_sub(mut self, nesting_depth: usize, sublist: bool, line: String) -> NestedString {
+        let mut refs_vec = vec![self];
+        for _ in 1..nesting_depth {
+            let mut high = refs_vec.pop().unwrap(); //unwrap will not panic, couse refs_vec has initial len>0 and then len is inreasing
+            let low = high.sub.pop();
+            refs_vec.push(high); //return to ref_vec what we has taken in this iteration(stripped of last element of sub)
             if let Some(low) = low {
-                refs_vec.push(low);//add to ref_vec last element of sub
+                refs_vec.push(low); //add to ref_vec last element of sub
+            } else {
+                refs_vec.push(NestedString::default());
             }
-            else { refs_vec.push(NestedString::default()); }
         }
-        if sublist  {refs_vec.last_mut().unwrap().sub.push(NestedString::new(line));}
-        else        {refs_vec.last_mut().unwrap().top.push(' ');
-                    refs_vec.last_mut().unwrap().top.push_str(line.as_str());}
-        
-        for _ in 1..nesting_depth
-        {
+        if sublist {
+            refs_vec
+                .last_mut()
+                .unwrap()
+                .sub
+                .push(NestedString::new(line));
+        } else {
+            refs_vec.last_mut().unwrap().top.push(' ');
+            refs_vec.last_mut().unwrap().top.push_str(line.as_str());
+        }
+
+        for _ in 1..nesting_depth {
             let last = refs_vec.pop().unwrap();
             refs_vec.last_mut().unwrap().sub.push(last);
         }
-        self=refs_vec.swap_remove(0);
+        self = refs_vec.swap_remove(0);
         self
     }
 }
 impl Display for NestedString {
     /// usable formating options:
-    /// :{width} - NestedString.top intendation/sublist depth, NestedString.sub is one sublist level deeper 
+    /// :{width} - NestedString.top intendation/sublist depth, NestedString.sub is one sublist level deeper
     /// :# - NestedString.top is at 0 sublist depth(no sublist at all), but NestedString.sub is on sublist level width+1
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut line_prefix=String::new();
-        let width=formatter.width().unwrap_or(0);
-        if !(width == 0 || formatter.alternate())
-        {
-            line_prefix += format!("{:>width$}","* ",width=2*width).as_str(); //set elements initial depth in list  
+        let mut line_prefix = String::new();
+        let width = formatter.width().unwrap_or(0);
+        if !(width == 0 || formatter.alternate()) {
+            line_prefix += format!("{:>width$}", "* ", width = 2 * width).as_str();
+            //set elements initial depth in list
         }
 
-        // if self.sub.is_empty()  
-        { write!(formatter, "{}{}", line_prefix, self.top)?; }
+        // if self.sub.is_empty()
+        {
+            write!(formatter, "{}{}", line_prefix, self.top)?;
+        }
         // else                    { write!(formatter, "{}{}\n", line_prefix, self.top); }
 
-        if self.sub.len()!=0
-        {
+        if self.sub.len() != 0 {
             // for (ns, last_elem) in self.sub.iter().enumerate()
             // .map(|(i, w)| (w, i == self.sub.len() - 1))
             // {
             //     if last_elem    { write!(formatter, "{:width$}", ns, width=width+1); }
             //     else            { write!(formatter, "{:width$}\n", ns, width=width+1); }
             // }
-            for ns in self.sub.iter()
-            {
-                write!(formatter, "\n{:width$}", ns, width=width+1)?; 
+            for ns in self.sub.iter() {
+                write!(formatter, "\n{:width$}", ns, width = width + 1)?;
             }
         }
         write!(formatter, "")
@@ -89,13 +95,13 @@ impl Display for NestedString {
 /// The enum used to represent the distinct _raw_ values of a comment
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum Value {
-    /// The first [`String`] is the _notation_ found, and the second [`String`] are the _contents without the notation_; the [`Vec<String>`] contains consecutive list (lines starting with "-") 
+    /// The first [`String`] is the _notation_ found, and .top of [`NestedString`] are the _contents without the notation_; the .sub of [`NestedString`] is a vector that contains consecutive list (lines starting with "-")
     Notation(String, NestedString),
     /// Raw text, without notation
     Text(NestedString),
     /// Double new-line, or any other separator
     Separator,
-    /// indented Text- probably continuation of previous line; [`String`]- line text stripped of leading whitespaces & sublist characters as '-','*'and '+'; [`usize`] - number of leading whitespaces; [`bool`]- sublist char present? 
+    /// indented Text- probably continuation of previous line; [`String`]- line text stripped of leading whitespaces & sublist characters as '-','*'and '+'; [`usize`] - number of leading whitespaces; [`bool`]- sublist char present?
     Continuation(String, usize, bool),
     /// Unknown value
     Unknown,
@@ -106,13 +112,18 @@ fn parse_single_line(line: &str) -> Value {
     let mut leading_whitespaces = 0;
     let mut chars_to_skip = 0;
     let mut sublist = false;
-    for ch in line.chars()
-    {
-        if ch.is_whitespace() && !sublist           { leading_whitespaces+=1; }
-        else if ch.is_whitespace()                  { }//just skip whitespaces after sublist mark
-        else if ch == '-' || ch == '*' || ch == '+' { sublist = true; }
-        else                                        { break; };
-        chars_to_skip+=1;
+    for ch in line.chars() {
+        if ch.is_whitespace() && !sublist {
+            leading_whitespaces += 1;
+        } else if ch.is_whitespace() {
+        }
+        //just skip whitespaces after sublist mark
+        else if ch == '-' || ch == '*' || ch == '+' {
+            sublist = true;
+        } else {
+            break;
+        };
+        chars_to_skip += 1;
     }
     line.drain(..chars_to_skip);
     if let Some(notation) = line.contains_any_notation() {
@@ -121,11 +132,11 @@ fn parse_single_line(line: &str) -> Value {
     } else if line.is_empty() {
         Value::Separator
     } else {
-        if leading_whitespaces > 0
-        {
+        if leading_whitespaces > 0 {
             Value::Continuation(line, leading_whitespaces, sublist)
+        } else {
+            Value::Text(NestedString::new(line))
         }
-        else{Value::Text(NestedString::new(line))}
     }
 }
 
@@ -138,10 +149,13 @@ fn parse_single_line(line: &str) -> Value {
 /// let parsed = parse_comment("@brief Random function");
 /// ```
 pub fn parse_comment(input: &str) -> Vec<Value> {
-    let lines = input.split('\n').map(|v| v.to_string()).collect::<Vec<String>>();
+    let lines = input
+        .split('\n')
+        .map(|v| v.to_string())
+        .collect::<Vec<String>>();
     let mut values = vec![];
-    let mut nesting_depth=0;
-    let mut nesting_spaces=vec![0];
+    let mut nesting_depth = 0;
+    let mut nesting_spaces = vec![0];
 
     for line in lines {
         let value = if line.trim().starts_with("* ") {
@@ -149,62 +163,51 @@ pub fn parse_comment(input: &str) -> Vec<Value> {
         } else {
             parse_single_line(line.as_str())
         };
-        if let Value::Continuation(line, leading_whitespaces, sublist) = value
-        {
-            for nd in (0..=nesting_depth).rev()
-            {
-                //asume that sublist level takes at least two whitespaces, and single whitespace is a typo 
-                if leading_whitespaces >= nesting_spaces[nd] + 2 
-                {//sublist level has increased
-                    nesting_depth += 1; 
+        if let Value::Continuation(line, leading_whitespaces, sublist) = value {
+            for nd in (0..=nesting_depth).rev() {
+                //asume that sublist level takes at least two whitespaces, and single whitespace is a typo
+                if leading_whitespaces >= nesting_spaces[nd] + 2 {
+                    //sublist level has increased
+                    nesting_depth += 1;
                     nesting_spaces.push(leading_whitespaces);
                     break;
-                }
-                else if leading_whitespaces + 2 <= nesting_spaces[nd] 
-                {//sublist level has decreased
+                } else if leading_whitespaces + 2 <= nesting_spaces[nd] {
+                    //sublist level has decreased
                     nesting_depth -= 1;
                     nesting_spaces.pop();
                     continue;
-                }
-                else 
-                {
+                } else {
                     break;
                 }
             }
-            match values.pop()
-            {
-                Some(Value::Notation(notation,mut values_depths)) => 
-                {
-                    values_depths=values_depths.modify_sub(nesting_depth, sublist, line);
+            match values.pop() {
+                Some(Value::Notation(notation, mut values_depths)) => {
+                    values_depths = values_depths.modify_sub(nesting_depth, sublist, line);
                     values.push(Value::Notation(notation.clone(), values_depths));
-                },
-                Some(Value::Text(mut values_depths)) => 
-                {
-                    values_depths=values_depths.modify_sub(nesting_depth, sublist, line);
+                }
+                Some(Value::Text(mut values_depths)) => {
+                    values_depths = values_depths.modify_sub(nesting_depth, sublist, line);
                     values.push(Value::Text(values_depths));
-                },
-                None => 
-                {//we shouldn't(?) be here (None means that this is first line, so it can not be continuation)
+                }
+                None => {
+                    //we shouldn't(?) be here (None means that this is first line, so it can not be continuation)
                     values.push(Value::Text(NestedString::new(line)));
                     nesting_depth = 0;
-                    nesting_spaces=vec![0];
-                },
-                Some(v) => {//we shouldn't(?) be here 
+                    nesting_spaces = vec![0];
+                }
+                Some(v) => {
+                    //we shouldn't(?) be here
                     values.push(v);
                     values.push(Value::Text(NestedString::new(line)));
                     nesting_depth = 0;
-                    nesting_spaces=vec![0];
-                },
+                    nesting_spaces = vec![0];
+                }
             }
-
-        }
-        else
-        {
+        } else {
             values.push(value);
             nesting_depth = 0;
-            nesting_spaces=vec![0];
+            nesting_spaces = vec![0];
         }
-
     }
     values.push(Value::Separator);
 
@@ -222,7 +225,10 @@ pub enum StringType {
 
 /// Generate a [`Vec`] of [`StringType`] from a given [`&str`], assuming it's a _raw_ bindgen file
 pub fn parse_bindgen(input: &str) -> Vec<StringType> {
-    let lines: Vec<String> = input.split('\n').map(|v| v.to_string()).collect::<Vec<String>>();
+    let lines: Vec<String> = input
+        .split('\n')
+        .map(|v| v.to_string())
+        .collect::<Vec<String>>();
     let mut strings = vec![];
 
     let mut comment_buffer = vec![];
@@ -231,7 +237,9 @@ pub fn parse_bindgen(input: &str) -> Vec<StringType> {
             comment_buffer.push(line.replace("#[doc = \"", "").replace("\"]", ""));
         } else {
             if !comment_buffer.is_empty() {
-                strings.push(StringType::Parsed(parse_comment(comment_buffer.join("\n").as_str())));
+                strings.push(StringType::Parsed(parse_comment(
+                    comment_buffer.join("\n").as_str(),
+                )));
                 comment_buffer = vec![];
             }
             strings.push(StringType::Raw(line));
@@ -244,8 +252,8 @@ pub fn parse_bindgen(input: &str) -> Vec<StringType> {
 #[cfg(test)]
 mod tests {
     use crate::parser::parse_comment;
-    use crate::parser::Value::Notation;
     use crate::parser::NestedString;
+    use crate::parser::Value::Notation;
 
     #[test]
     fn test() {
@@ -256,13 +264,30 @@ mod tests {
     #[test]
     fn italic_works() {
         let parsed = parse_comment("@brief \\a example \\\\e example 2 @em example 3");
-        assert_eq!(parsed[0], Notation("@brief".to_owned(), NestedString{top:"*example* *example* 2 *example* 3".to_owned(), sub:vec![]}))
+        assert_eq!(
+            parsed[0],
+            Notation(
+                "@brief".to_owned(),
+                NestedString {
+                    top: "*example* *example* 2 *example* 3".to_owned(),
+                    sub: vec![]
+                }
+            )
+        )
     }
 
     #[test]
     fn emojis_work() {
         let parsed = parse_comment("@brief @emoji :smirk: \\emoji smirk \\\\emoji smiley");
-        assert_eq!(parsed[0], Notation("@brief".to_owned(), NestedString{top:"😏 😏 😃".to_owned(), sub:vec![]}))
+        assert_eq!(
+            parsed[0],
+            Notation(
+                "@brief".to_owned(),
+                NestedString {
+                    top: "😏 😏 😃".to_owned(),
+                    sub: vec![]
+                }
+            )
+        )
     }
 }
-

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2,32 +2,130 @@
 //!
 //! **The functions and structs here should _not_ be considered stable**
 
+use std::fmt::{Display};
+
 use crate::utils::NotationMatching;
 
 mod preprocessor;
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct NestedString
+{
+    pub top: String,
+    pub sub: Vec<NestedString>
+}
+impl Default for NestedString
+{
+    fn default() -> Self {
+        Self { top: Default::default(), sub: Default::default() }
+    }
+}
+impl NestedString
+{
+    pub fn new(top: String) -> Self { Self { top, sub:vec![] } }
 
+    pub fn to_string(&self)->String
+    {
+        format!("{}",self)
+    }
+
+    pub fn modify_sub(mut self, nesting_depth : usize, sublist : bool, line: String)->NestedString
+    {
+        let mut refs_vec=vec![self];
+        for _ in 1..nesting_depth
+        {
+            let mut high=refs_vec.pop().unwrap();//unwrap will not panic, couse refs_vec has initial len>0 and then len is inreasing
+            let low= high.sub.pop();
+            refs_vec.push(high);//return to ref_vec what we has taken in this iteration(stripped of last element of sub)
+            if let Some(low) = low {
+                refs_vec.push(low);//add to ref_vec last element of sub
+            }
+            else { refs_vec.push(NestedString::default()); }
+        }
+        if sublist  {refs_vec.last_mut().unwrap().sub.push(NestedString::new(line));}
+        else        {refs_vec.last_mut().unwrap().top.push(' ');
+                    refs_vec.last_mut().unwrap().top.push_str(line.as_str());}
+        
+        for _ in 1..nesting_depth
+        {
+            let last = refs_vec.pop().unwrap();
+            refs_vec.last_mut().unwrap().sub.push(last);
+        }
+        self=refs_vec.swap_remove(0);
+        self
+    }
+}
+impl Display for NestedString {
+    /// usable formating options:
+    /// :{width} - NestedString.top intendation/sublist depth, NestedString.sub is one sublist level deeper 
+    /// :# - NestedString.top is at 0 sublist depth(no sublist at all), but NestedString.sub is on sublist level width+1
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut line_prefix=String::new();
+        let width=formatter.width().unwrap_or(0);
+        if !(width == 0 || formatter.alternate())
+        {
+            line_prefix += format!("{:>width$}","* ",width=2*width).as_str(); //set elements initial depth in list  
+        }
+
+        // if self.sub.is_empty()  
+        { write!(formatter, "{}{}", line_prefix, self.top)?; }
+        // else                    { write!(formatter, "{}{}\n", line_prefix, self.top); }
+
+        if self.sub.len()!=0
+        {
+            // for (ns, last_elem) in self.sub.iter().enumerate()
+            // .map(|(i, w)| (w, i == self.sub.len() - 1))
+            // {
+            //     if last_elem    { write!(formatter, "{:width$}", ns, width=width+1); }
+            //     else            { write!(formatter, "{:width$}\n", ns, width=width+1); }
+            // }
+            for ns in self.sub.iter()
+            {
+                write!(formatter, "\n{:width$}", ns, width=width+1)?; 
+            }
+        }
+        write!(formatter, "")
+    }
+}
 /// The enum used to represent the distinct _raw_ values of a comment
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum Value {
-    /// The first [`String`] is the _notation_ found, and the second [`String`] are the _contents without the notation_
-    Notation(String, String),
+    /// The first [`String`] is the _notation_ found, and the second [`String`] are the _contents without the notation_; the [`Vec<String>`] contains consecutive list (lines starting with "-") 
+    Notation(String, NestedString),
     /// Raw text, without notation
-    Text(String),
+    Text(NestedString),
     /// Double new-line, or any other separator
     Separator,
+    /// indented Text- probably continuation of previous line; [`String`]- line text stripped of leading whitespaces & sublist characters as '-','*'; [`usize`] - number of leading whitespaces; [`bool`]- sublist char present? 
+    Continuation(String, usize, bool),
     /// Unknown value
     Unknown,
 }
 
 fn parse_single_line(line: &str) -> Value {
-    let line = preprocessor::preprocess_line(line);
+    let mut line = preprocessor::preprocess_line(line);
+    let mut leading_whitespaces = 0;
+    let mut chars_to_skip = 0;
+    let mut sublist = false;
+    for ch in line.chars()
+    {
+        if ch.is_whitespace() && !sublist   { leading_whitespaces+=1; }
+        else if ch.is_whitespace()          { }//just skip whitespaces after sublist mark
+        else if ch == '-' || ch == '*'      { sublist = true; }
+        else                                { break; };
+        chars_to_skip+=1;
+    }
+    line.drain(..chars_to_skip);
     if let Some(notation) = line.contains_any_notation() {
         let split = line.split_whitespace().collect::<Vec<&str>>();
-        Value::Notation(notation, split[1..].to_vec().join(" "))
+        Value::Notation(notation, NestedString::new(split[1..].to_vec().join(" ")))
     } else if line.is_empty() {
         Value::Separator
     } else {
-        Value::Text(line)
+        if leading_whitespaces > 0
+        {
+            Value::Continuation(line, leading_whitespaces, sublist)
+        }
+        else{Value::Text(NestedString::new(line))}
     }
 }
 
@@ -42,6 +140,8 @@ fn parse_single_line(line: &str) -> Value {
 pub fn parse_comment(input: &str) -> Vec<Value> {
     let lines = input.split('\n').map(|v| v.to_string()).collect::<Vec<String>>();
     let mut values = vec![];
+    let mut nesting_depth=0;
+    let mut nesting_spaces=vec![0];
 
     for line in lines {
         let value = if line.trim().starts_with("* ") {
@@ -49,8 +149,62 @@ pub fn parse_comment(input: &str) -> Vec<Value> {
         } else {
             parse_single_line(line.as_str())
         };
+        if let Value::Continuation(line, leading_whitespaces, sublist) = value
+        {
+            for nd in (0..=nesting_depth).rev()
+            {
+                //asume that sublist level takes at least two whitespaces, and single whitespace is a typo 
+                if leading_whitespaces >= nesting_spaces[nd] + 2 
+                {//sublist level has increased
+                    nesting_depth += 1; 
+                    nesting_spaces.push(leading_whitespaces);
+                    break;
+                }
+                else if leading_whitespaces + 2 <= nesting_spaces[nd] 
+                {//sublist level has decreased
+                    nesting_depth -= 1;
+                    nesting_spaces.pop();
+                    continue;
+                }
+                else 
+                {
+                    break;
+                }
+            }
+            match values.pop()
+            {
+                Some(Value::Notation(notation,mut values_depths)) => 
+                {
+                    values_depths=values_depths.modify_sub(nesting_depth, sublist, line);
+                    values.push(Value::Notation(notation.clone(), values_depths));
+                },
+                Some(Value::Text(mut values_depths)) => 
+                {
+                    values_depths=values_depths.modify_sub(nesting_depth, sublist, line);
+                    values.push(Value::Text(values_depths));
+                },
+                None => 
+                {//we shouldn't(?) be here (None means that this is first line, so it can not be continuation)
+                    values.push(Value::Text(NestedString::new(line)));
+                    nesting_depth = 0;
+                    nesting_spaces=vec![0];
+                },
+                Some(v) => {//we shouldn't(?) be here 
+                    values.push(v);
+                    values.push(Value::Text(NestedString::new(line)));
+                    nesting_depth = 0;
+                    nesting_spaces=vec![0];
+                },
+            }
 
-        values.push(value);
+        }
+        else
+        {
+            values.push(value);
+            nesting_depth = 0;
+            nesting_spaces=vec![0];
+        }
+
     }
     values.push(Value::Separator);
 
@@ -91,6 +245,7 @@ pub fn parse_bindgen(input: &str) -> Vec<StringType> {
 mod tests {
     use crate::parser::parse_comment;
     use crate::parser::Value::Notation;
+    use crate::parser::NestedString;
 
     #[test]
     fn test() {
@@ -101,13 +256,13 @@ mod tests {
     #[test]
     fn italic_works() {
         let parsed = parse_comment("@brief \\a example \\\\e example 2 @em example 3");
-        assert_eq!(parsed[0], Notation("@brief".to_owned(), "*example* *example* 2 *example* 3".to_owned()))
+        assert_eq!(parsed[0], Notation("@brief".to_owned(), NestedString{top:"*example* *example* 2 *example* 3".to_owned(), sub:vec![]}))
     }
 
     #[test]
     fn emojis_work() {
         let parsed = parse_comment("@brief @emoji :smirk: \\emoji smirk \\\\emoji smiley");
-        assert_eq!(parsed[0], Notation("@brief".to_owned(), "😏 😏 😃".to_owned()))
+        assert_eq!(parsed[0], Notation("@brief".to_owned(), NestedString{top:"😏 😏 😃".to_owned(), sub:vec![]}))
     }
 }
 

--- a/src/parser/preprocessor/emojis.rs
+++ b/src/parser/preprocessor/emojis.rs
@@ -1,4 +1,4 @@
-use phf::{phf_map};
+use phf::phf_map;
 
 // Source: https://gist.github.com/rxaviers/7360908 from https://doxygen.nl/manual/commands.html#cmdemoji
 pub(crate) static EMOJIS: phf::Map<&'static str, &'static str> = phf_map! {

--- a/src/parser/preprocessor/mod.rs
+++ b/src/parser/preprocessor/mod.rs
@@ -19,7 +19,7 @@ pub fn preprocess_line(input: &str) -> String {
 fn add_emojis(input: &str) -> String {
     let mut apply_emoji_to_next = false;
     input
-        .split_whitespace()
+    .split(char::is_whitespace)
         .map(|v| {
             if apply_emoji_to_next {
                 apply_emoji_to_next = false;
@@ -38,7 +38,7 @@ fn add_emojis(input: &str) -> String {
 fn make_italic_text(input: &str) -> String {
     let mut apply_italic_to_next = false;
     input
-        .split_whitespace()
+        .split(char::is_whitespace)
         .map(|v| {
             if apply_italic_to_next {
                 apply_italic_to_next = false;
@@ -56,7 +56,7 @@ fn make_italic_text(input: &str) -> String {
 
 fn make_links_clickable(input: &str) -> String {
     input
-        .split_whitespace()
+    .split(char::is_whitespace)
         .map(|v| {
             if v.starts_with("http://") || v.starts_with("https://") {
                 let v = remove_trailing_dot_or_colon(v);
@@ -72,7 +72,7 @@ fn make_links_clickable(input: &str) -> String {
 fn make_refs_clickable(input: &str) -> String {
     let mut apply_ref_to_next = false;
     input
-        .split_whitespace()
+    .split(char::is_whitespace)
         .map(|v| {
             if apply_ref_to_next {
                 let v = remove_trailing_dot_or_colon(v);
@@ -92,7 +92,7 @@ fn make_refs_clickable(input: &str) -> String {
 
 fn render_code(input: &str) -> String {
     input
-        .split_whitespace()
+    .split(char::is_whitespace)
         .map(|v| {
             if v.contains_notation("code") {
                 "```\n".to_string()

--- a/src/parser/preprocessor/mod.rs
+++ b/src/parser/preprocessor/mod.rs
@@ -7,23 +7,23 @@ mod emojis;
 pub fn preprocess_line(input: &str) -> String {
     render_code(
         make_italic_text(
-            add_emojis(
-                make_refs_clickable(
-                    make_links_clickable(input).as_str()
-                ).as_str()
-            ).as_str()
-        ).as_str()
+            add_emojis(make_refs_clickable(make_links_clickable(input).as_str()).as_str()).as_str(),
+        )
+        .as_str(),
     )
 }
 
 fn add_emojis(input: &str) -> String {
     let mut apply_emoji_to_next = false;
     input
-    .split(char::is_whitespace)
+        .split(char::is_whitespace)
         .map(|v| {
             if apply_emoji_to_next {
                 apply_emoji_to_next = false;
-                EMOJIS.get(v.replace(":", "").as_str()).unwrap_or(&"Unknown emoji").to_string()
+                EMOJIS
+                    .get(v.replace(":", "").as_str())
+                    .unwrap_or(&"Unknown emoji")
+                    .to_string()
             } else if v.contains_notation("emoji") {
                 apply_emoji_to_next = true;
                 "".to_owned()
@@ -43,7 +43,10 @@ fn make_italic_text(input: &str) -> String {
             if apply_italic_to_next {
                 apply_italic_to_next = false;
                 format!("*{}*", v)
-            } else if v.contains_notation("a") || v.contains_notation("em") || v.contains_notation("e") {
+            } else if v.contains_notation("a")
+                || v.contains_notation("em")
+                || v.contains_notation("e")
+            {
                 apply_italic_to_next = true;
                 "".to_owned()
             } else {
@@ -56,7 +59,7 @@ fn make_italic_text(input: &str) -> String {
 
 fn make_links_clickable(input: &str) -> String {
     input
-    .split(char::is_whitespace)
+        .split(char::is_whitespace)
         .map(|v| {
             if v.starts_with("http://") || v.starts_with("https://") {
                 let v = remove_trailing_dot_or_colon(v);
@@ -72,14 +75,17 @@ fn make_links_clickable(input: &str) -> String {
 fn make_refs_clickable(input: &str) -> String {
     let mut apply_ref_to_next = false;
     input
-    .split(char::is_whitespace)
+        .split(char::is_whitespace)
         .map(|v| {
             if apply_ref_to_next {
                 let v = remove_trailing_dot_or_colon(v);
 
                 apply_ref_to_next = false;
                 format!("[`{}`]", v)
-            } else if v.contains_notation("ref") || v.contains_notation("sa") || v.contains_notation("see") {
+            } else if v.contains_notation("ref")
+                || v.contains_notation("sa")
+                || v.contains_notation("see")
+            {
                 apply_ref_to_next = true;
                 "".to_owned()
             } else {
@@ -92,7 +98,7 @@ fn make_refs_clickable(input: &str) -> String {
 
 fn render_code(input: &str) -> String {
     input
-    .split(char::is_whitespace)
+        .split(char::is_whitespace)
         .map(|v| {
             if v.contains_notation("code") {
                 "```\n".to_string()

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -10,15 +10,21 @@ macro_rules! notation_matching {
     ($t:ty) => {
         impl NotationMatching for $t {
             fn starts_with_notation(&self, notation: &str) -> bool {
-                self.starts_with(format!("@{}", notation).as_str()) || self.starts_with(format!("\\{}", notation).as_str()) || self.starts_with(format!("\\\\{}", notation).as_str())
+                self.starts_with(format!("@{}", notation).as_str())
+                    || self.starts_with(format!("\\{}", notation).as_str())
+                    || self.starts_with(format!("\\\\{}", notation).as_str())
             }
 
             fn replace_notation(&self, notation: &str, to: &str) -> String {
-                self.replace(format!("@{}", notation).as_str(), to).replace(format!("\\{}", notation).as_str(), to).replace(format!("\\\\{}", notation).as_str(), to)
+                self.replace(format!("@{}", notation).as_str(), to)
+                    .replace(format!("\\{}", notation).as_str(), to)
+                    .replace(format!("\\\\{}", notation).as_str(), to)
             }
 
             fn contains_notation(&self, notation: &str) -> bool {
-                self.contains(format!("@{}", notation).as_str()) || self.contains(format!("\\{}", notation).as_str()) || self.contains(format!("\\\\{}", notation).as_str())
+                self.contains(format!("@{}", notation).as_str())
+                    || self.contains(format!("\\{}", notation).as_str())
+                    || self.contains(format!("\\\\{}", notation).as_str())
             }
 
             fn remove_notation(&self, notation: &str) -> String {
@@ -34,7 +40,7 @@ macro_rules! notation_matching {
                 }
             }
         }
-    }
+    };
 }
 
 notation_matching!(&str);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -26,7 +26,7 @@ macro_rules! notation_matching {
             }
 
             fn contains_any_notation(&self) -> Option<String> {
-                if self.trim().starts_with("@") || self.trim().starts_with("\\") || self.trim().starts_with("\\\\") {
+                if self.starts_with("@") || self.starts_with("\\") || self.starts_with("\\\\") {
                     let split = self.split_whitespace().collect::<Vec<&str>>();
                     Some(split.first()?.to_string())
                 } else {


### PR DESCRIPTION
(all examples used below taken from NordicSemiconductor Softdevice API)
In doxygen param, retval and other Notation's are allowed to contain sublists eg.
``` 
 * @retval ::NRF_ERROR_INVALID_STATE One or more of the following is true:
 *                                   - Invalid Connection State
 *                                   - Notifications and/or indications not enabled in the CCCD
 *                                   - An ATT_MTU exchange is ongoing
``` 
 currently doxygen-rs parses all lines separately and splits this into:
[in top/function description section ]
```
///- Invalid Connection State
///- Notifications and/or indications not enabled in the CCCD
///- An ATT_MTU exchange is ongoing
```
[in return values section]
```
///* ::NRF_ERROR_INVALID_STATE One or more of the following is true: 
```
Which produces total mess. After PR this would look like:
```
///* ::NRF_ERROR_INVALID_STATE One or more of the following is true:
///  * Invalid Connection State
///  * Notifications and/or indications not enabled in the CCCD
///  * An ATT_MTU exchange is ongoing
```
(all in one section)
Second thing currently not supported by doxygen-rs is line/sentence split into multiple line (probably to force maximum line width). eg.
```
 * @param[in,out] p_hvx_params Pointer to an HVx parameters structure. If @ref ble_gatts_hvx_params_t::p_data
 *                             contains a non-NULL pointer the attribute value will be updated with the contents
 *                             pointed by it before sending the notification or indication. If the attribute value
 *                             is updated, @ref ble_gatts_hvx_params_t::p_len is updated by the SoftDevice to
 *                             contain the number of actual bytes written, else it will be set to 0.
```
and one more time doxygen-rs splits this and places it in different sections.
This Pull Request aims to improve behavior in this two cases
(how it works:
it replaces String in bunch of places with NestedString that is able to logicaly represent sublist;
in parser if indentation is detected it is assumed that current line is continuation to previous one
and previous NestedString is modified: either new element is pushed to NestedString.sub(in case of sublist) or line is appended to NestedString.top string(in case of multi line sentence)
)
sample function docs:
<details>
<summary>doxygen</summary>

```
/**@brief Notify or Indicate an attribute value.
 *
 * @details This function checks for the relevant Client Characteristic Configuration descriptor value to verify that the relevant operation
 *          (notification or indication) has been enabled by the client. It is also able to update the attribute value before issuing the PDU, so that
 *          the application can atomically perform a value update and a server initiated transaction with a single API call.
 *
 * @note    The local attribute value may be updated even if an outgoing packet is not sent to the peer due to an error during execution.
 *          The Attribute Table has been updated if one of the following error codes is returned: @ref NRF_ERROR_INVALID_STATE, @ref NRF_ERROR_BUSY,
 *          @ref NRF_ERROR_FORBIDDEN, @ref BLE_ERROR_GATTS_SYS_ATTR_MISSING and @ref NRF_ERROR_RESOURCES.
 *          The caller can check whether the value has been updated by looking at the contents of *(@ref ble_gatts_hvx_params_t::p_len).
 *
 * @note    Only one indication procedure can be ongoing per connection at a time.
 *          If the application tries to indicate an attribute value while another indication procedure is ongoing,
 *          the function call will return @ref NRF_ERROR_BUSY.
 *          A @ref BLE_GATTS_EVT_HVC event will be issued as soon as the confirmation arrives from the peer.
 *
 * @note    The number of Handle Value Notifications that can be queued is configured by @ref ble_gatts_conn_cfg_t::hvn_tx_queue_size
 *          When the queue is full, the function call will return @ref NRF_ERROR_RESOURCES.
 *          A @ref BLE_GATTS_EVT_HVN_TX_COMPLETE event will be issued as soon as the transmission of the notification is complete.
 *
 * @note    The application can keep track of the available queue element count for notifications by following the procedure below:
 *          - Store initial queue element count in a variable.
 *          - Decrement the variable, which stores the currently available queue element count, by one when a call to this function returns @ref NRF_SUCCESS.
 *          - Increment the variable, which stores the current available queue element count, by the count variable in @ref BLE_GATTS_EVT_HVN_TX_COMPLETE event.
 *
 * @events
 * @event{@ref BLE_GATTS_EVT_HVN_TX_COMPLETE, Notification transmission complete.}
 * @event{@ref BLE_GATTS_EVT_HVC, Confirmation received from the peer.}
 * @endevents
 *
 * @mscs
 * @mmsc{@ref BLE_GATTS_HVX_SYS_ATTRS_MISSING_MSC}
 * @mmsc{@ref BLE_GATTS_HVN_MSC}
 * @mmsc{@ref BLE_GATTS_HVI_MSC}
 * @mmsc{@ref BLE_GATTS_HVX_DISABLED_MSC}
 * @endmscs
 *
 * @param[in] conn_handle      Connection handle.
 * @param[in,out] p_hvx_params Pointer to an HVx parameters structure. If @ref ble_gatts_hvx_params_t::p_data
 *                             contains a non-NULL pointer the attribute value will be updated with the contents
 *                             pointed by it before sending the notification or indication. If the attribute value
 *                             is updated, @ref ble_gatts_hvx_params_t::p_len is updated by the SoftDevice to
 *                             contain the number of actual bytes written, else it will be set to 0.
 *
 * @retval ::NRF_SUCCESS Successfully queued a notification or indication for transmission, and optionally updated the attribute value.
 * @retval ::BLE_ERROR_INVALID_CONN_HANDLE Invalid Connection Handle.
 * @retval ::NRF_ERROR_INVALID_STATE One or more of the following is true:
 *                                   - Invalid Connection State
 *                                   - Notifications and/or indications not enabled in the CCCD
 *                                   - An ATT_MTU exchange is ongoing
 * @retval ::NRF_ERROR_INVALID_ADDR Invalid pointer supplied.
 * @retval ::NRF_ERROR_INVALID_PARAM Invalid parameter(s) supplied.
 * @retval ::BLE_ERROR_INVALID_ATTR_HANDLE Invalid attribute handle(s) supplied. Only attributes added directly by the application are available to notify and indicate.
 * @retval ::BLE_ERROR_GATTS_INVALID_ATTR_TYPE Invalid attribute type(s) supplied, only characteristic values may be notified and indicated.
 * @retval ::NRF_ERROR_NOT_FOUND Attribute not found.
 * @retval ::NRF_ERROR_FORBIDDEN The connection's current security level is lower than the one required by the write permissions of the CCCD associated with this characteristic.
 * @retval ::NRF_ERROR_DATA_SIZE Invalid data size(s) supplied.
 * @retval ::NRF_ERROR_BUSY For @ref BLE_GATT_HVX_INDICATION Procedure already in progress. Wait for a @ref BLE_GATTS_EVT_HVC event and retry.
 * @retval ::BLE_ERROR_GATTS_SYS_ATTR_MISSING System attributes missing, use @ref sd_ble_gatts_sys_attr_set to set them to a known value.
 * @retval ::NRF_ERROR_RESOURCES Too many notifications queued.
 *                               Wait for a @ref BLE_GATTS_EVT_HVN_TX_COMPLETE event and retry.
 * @retval ::NRF_ERROR_TIMEOUT There has been a GATT procedure timeout. No new GATT procedure can be performed without reestablishing the connection.
 */
```

</details>
<details>
<summary>before PR</summary>

```
///Notify or Indicate an attribute value.
///
///This function checks for the relevant Client Characteristic Configuration descriptor value to verify that the relevant operation
///(notification or indication) has been enabled by the client. It is also able to update the attribute value before issuing the PDU, so that
///the application can atomically perform a value update and a server initiated transaction with a single API call.
///The Attribute Table has been updated if one of the following error codes is returned: [`NRF_ERROR_INVALID_STATE`] [`NRF_ERROR_BUSY`]
///[`NRF_ERROR_FORBIDDEN`] [`BLE_ERROR_GATTS_SYS_ATTR_MISSING`] and [`NRF_ERROR_RESOURCES`]
///The caller can check whether the value has been updated by looking at the contents of [`ble_gatts_hvx_params_t::p_len)`]
///If the application tries to indicate an attribute value while another indication procedure is ongoing,
///the function call will return [`NRF_ERROR_BUSY`]
///A [`BLE_GATTS_EVT_HVC`] event will be issued as soon as the confirmation arrives from the peer.
///When the queue is full, the function call will return [`NRF_ERROR_RESOURCES`]
///A [`BLE_GATTS_EVT_HVN_TX_COMPLETE`] event will be issued as soon as the transmission of the notification is complete.
///- Store initial queue element count in a variable.
///- Decrement the variable, which stores the currently available queue element count, by one when a call to this function returns [`NRF_SUCCESS`]
///- Increment the variable, which stores the current available queue element count, by the count variable in [`BLE_GATTS_EVT_HVN_TX_COMPLETE`] event.
///[`BLE_GATTS_EVT_HVN_TX_COMPLETE`] Notification transmission complete.}
///[`BLE_GATTS_EVT_HVC`] Confirmation received from the peer.}
///[`BLE_GATTS_HVX_SYS_ATTRS_MISSING_MSC}`]
///[`BLE_GATTS_HVN_MSC}`]
///[`BLE_GATTS_HVI_MSC}`]
///[`BLE_GATTS_HVX_DISABLED_MSC}`]
///contains a non-NULL pointer the attribute value will be updated with the contents
///pointed by it before sending the notification or indication. If the attribute value
///is updated, [`ble_gatts_hvx_params_t::p_len`] is updated by the SoftDevice to
///contain the number of actual bytes written, else it will be set to 0.
///- Invalid Connection State
///- Notifications and/or indications not enabled in the CCCD
///- An ATT_MTU exchange is ongoing
///Wait for a [`BLE_GATTS_EVT_HVN_TX_COMPLETE`] event and retry.
///
///# Arguments
///
///* `conn_handle` - Connection handle. [Direction: In]
///* `p_hvx_params` - Pointer to an HVx parameters structure. If [`ble_gatts_hvx_params_t::p_data`] [Direction: Out]
///
///# Return values
///* ::NRF_SUCCESS Successfully queued a notification or indication for transmission, and optionally updated the attribute value.
///* ::BLE_ERROR_INVALID_CONN_HANDLE Invalid Connection Handle.
///* ::NRF_ERROR_INVALID_STATE One or more of the following is true:
///* ::NRF_ERROR_INVALID_ADDR Invalid pointer supplied.
///* ::NRF_ERROR_INVALID_PARAM Invalid parameter(s) supplied.
///* ::BLE_ERROR_INVALID_ATTR_HANDLE Invalid attribute handle(s) supplied. Only attributes added directly by the application are available to notify and indicate.
///* ::BLE_ERROR_GATTS_INVALID_ATTR_TYPE Invalid attribute type(s) supplied, only characteristic values may be notified and indicated.
///* ::NRF_ERROR_NOT_FOUND Attribute not found.
///* ::NRF_ERROR_FORBIDDEN The connection's current security level is lower than the one required by the write permissions of the CCCD associated with this characteristic.
///* ::NRF_ERROR_DATA_SIZE Invalid data size(s) supplied.
///* ::NRF_ERROR_BUSY For [`BLE_GATT_HVX_INDICATION`] Procedure already in progress. Wait for a [`BLE_GATTS_EVT_HVC`] event and retry.
///* ::BLE_ERROR_GATTS_SYS_ATTR_MISSING System attributes missing, use [`sd_ble_gatts_sys_attr_set`] to set them to a known value.
///* ::NRF_ERROR_RESOURCES Too many notifications queued.
///* ::NRF_ERROR_TIMEOUT There has been a GATT procedure timeout. No new GATT procedure can be performed without reestablishing the connection.
///
///# Notes
///
///* The local attribute value may be updated even if an outgoing packet is not sent to the peer due to an error during execution.
///* Only one indication procedure can be ongoing per connection at a time.
///* The number of Handle Value Notifications that can be queued is configured by [`ble_gatts_conn_cfg_t::hvn_tx_queue_size`]
///* The application can keep track of the available queue element count for notifications by following the procedure below:
///
```

</details>
<details>
<summary>after PR</summary>

```
///Notify or Indicate an attribute value.
///
///This function checks for the relevant Client Characteristic Configuration descriptor value to verify that the relevant operation (notification or indication) has been enabled by the client. It is also able to update the attribute value before issuing the PDU, so that the application can atomically perform a value update and a server initiated transaction with a single API call.
///[`BLE_GATTS_EVT_HVN_TX_COMPLETE`] Notification transmission complete.} [`BLE_GATTS_EVT_HVC`] Confirmation received from the peer.}
///
///# Arguments
///
///* `conn_handle` - [Direction: In] Connection handle.
///* `p_hvx_params` - [Direction: Out] Pointer to an HVx parameters structure. If [`ble_gatts_hvx_params_t::p_data`] contains a non-NULL pointer the attribute value will be updated with the contents pointed by it before sending the notification or indication. If the attribute value is updated,  [`ble_gatts_hvx_params_t::p_len`] is updated by the SoftDevice to contain the number of actual bytes written, else it will be set to 0.
///
///# Return values
///* ::NRF_SUCCESS Successfully queued a notification or indication for transmission, and optionally updated the attribute value.
///* ::BLE_ERROR_INVALID_CONN_HANDLE Invalid Connection Handle.
///* ::NRF_ERROR_INVALID_STATE One or more of the following is true:
///  * Invalid Connection State
///  * Notifications and/or indications not enabled in the CCCD
///  * An ATT_MTU exchange is ongoing
///* ::NRF_ERROR_INVALID_ADDR Invalid pointer supplied.
///* ::NRF_ERROR_INVALID_PARAM Invalid parameter(s) supplied.
///* ::BLE_ERROR_INVALID_ATTR_HANDLE Invalid attribute handle(s) supplied. Only attributes added directly by the application are available to notify and indicate.
///* ::BLE_ERROR_GATTS_INVALID_ATTR_TYPE Invalid attribute type(s) supplied, only characteristic values may be notified and indicated.
///* ::NRF_ERROR_NOT_FOUND Attribute not found.
///* ::NRF_ERROR_FORBIDDEN The connection's current security level is lower than the one required by the write permissions of the CCCD associated with this characteristic.
///* ::NRF_ERROR_DATA_SIZE Invalid data size(s) supplied.
///* ::NRF_ERROR_BUSY For [`BLE_GATT_HVX_INDICATION`] Procedure already in progress. Wait for a [`BLE_GATTS_EVT_HVC`] event and retry.
///* ::BLE_ERROR_GATTS_SYS_ATTR_MISSING System attributes missing, use [`sd_ble_gatts_sys_attr_set`] to set them to a known value.
///* ::NRF_ERROR_RESOURCES Too many notifications queued. Wait for a  [`BLE_GATTS_EVT_HVN_TX_COMPLETE`] event and retry.
///* ::NRF_ERROR_TIMEOUT There has been a GATT procedure timeout. No new GATT procedure can be performed without reestablishing the connection.
///
///# Notes
///
///* The local attribute value may be updated even if an outgoing packet is not sent to the peer due to an error during execution. The Attribute Table has been updated if one of the following error codes is returned:  [`NRF_ERROR_INVALID_STATE`]  [`NRF_ERROR_BUSY`] [`NRF_ERROR_FORBIDDEN`]  [`BLE_ERROR_GATTS_SYS_ATTR_MISSING`] and  [`NRF_ERROR_RESOURCES`] The caller can check whether the value has been updated by looking at the contents of  [`ble_gatts_hvx_params_t::p_len)`]
///* Only one indication procedure can be ongoing per connection at a time. If the application tries to indicate an attribute value while another indication procedure is ongoing, the function call will return  [`NRF_ERROR_BUSY`] A  [`BLE_GATTS_EVT_HVC`] event will be issued as soon as the confirmation arrives from the peer.
///* The number of Handle Value Notifications that can be queued is configured by [`ble_gatts_conn_cfg_t::hvn_tx_queue_size`] When the queue is full, the function call will return  [`NRF_ERROR_RESOURCES`] A  [`BLE_GATTS_EVT_HVN_TX_COMPLETE`] event will be issued as soon as the transmission of the notification is complete.
///* The application can keep track of the available queue element count for notifications by following the procedure below:
///  * Store initial queue element count in a variable.
///  * Decrement the variable, which stores the currently available queue element count, by one when a call to this function returns  [`NRF_SUCCESS`]
///  * Increment the variable, which stores the current available queue element count, by the count variable in  [`BLE_GATTS_EVT_HVN_TX_COMPLETE`] event.
///
```

</details>
<details>
<summary>generated docs before PR</summary>

![obraz](https://user-images.githubusercontent.com/46752179/213295494-1957116c-a906-4fa6-a839-0b0ea7bd435b.png)

</details>
</details>
<details>
<summary>generated docs after PR</summary>

![obraz](https://user-images.githubusercontent.com/46752179/213295360-4f484714-0530-4a59-abd1-7a251f47e68b.png)

</details>