### PR TITLE
Added support for @code ... @endocde commands

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -173,7 +173,11 @@ fn generate_notation(
             "par" => String::from("# "),
             "details" | "pre" | "post" => String::from("\n\n"),
             "brief" | "short" => String::new(),
-            "code" => String::from("```"),
+            "code" => {
+                let lang = params.get(0).map(|p| p.as_str()).unwrap_or_default();
+                let lang = lang.strip_prefix('.').unwrap_or(lang);
+                format!("```{lang}")
+            }
             "endcode" => String::from("```"),
             _ => String::new(),
         },
@@ -368,6 +372,14 @@ mod test {
         test_rustdoc!(
             "@code\nfn main() {\n        test( [1] ); // @code @throw\n@endcode",
             "```\nfn main() {\n        test( [1] ); // @code @throw\n```"
+        );
+    }
+
+    #[test]
+    fn code_with_lang() {
+        test_rustdoc!(
+            "@code{.rs}\nfn main() {\n        test( [1] ); // @code @throw\n@endcode",
+            "```rs\nfn main() {\n        test( [1] ); // @code @throw\n```"
         );
     }
 

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -42,20 +42,22 @@ pub fn rustdoc(input: String) -> Result<String, ParseError> {
 
                 str
             }
-            GrammarItem::Text(v) => if group_started {
-                v.replacen("*", "", 1)
-            } else {
-                v
-            },
+            GrammarItem::Text(v) => {
+                if group_started {
+                    v.replacen("*", "", 1)
+                } else {
+                    v
+                }
+            }
             // See <https://stackoverflow.com/a/40354789>
             GrammarItem::GroupStart => {
                 group_started = true;
                 String::from("# ")
-            },
+            }
             GrammarItem::GroupEnd => {
                 group_started = false;
-                continue
-            },
+                continue;
+            }
         };
     }
 
@@ -171,6 +173,8 @@ fn generate_notation(
             "par" => String::from("# "),
             "details" | "pre" | "post" => String::from("\n\n"),
             "brief" | "short" => String::new(),
+            "code" => String::from("```"),
+            "endcode" => String::from("```"),
             _ => String::new(),
         },
         (new_param, new_return, new_throw),
@@ -356,6 +360,14 @@ mod test {
         test_rustdoc!(
             "@throw std::io::bonk This is thrown when INSANE things happen.\n@throws std::net::meow This is thrown when BAD things happen.\n@exception std::fs::no This is thrown when NEFARIOUS things happen.",
             "# Throws\n\n* [`std::io::bonk`] - This is thrown when INSANE things happen.\n* [`std::net::meow`] - This is thrown when BAD things happen.\n* [`std::fs::no`] - This is thrown when NEFARIOUS things happen."
+        );
+    }
+
+    #[test]
+    fn code() {
+        test_rustdoc!(
+            "@code\nfn main() {\n        test( [1] ); // @code @throw\n@endcode",
+            "```\nfn main() {\n        test( [1] ); // @code @throw\n```"
         );
     }
 

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -174,7 +174,7 @@ fn generate_notation(
             "details" | "pre" | "post" => String::from("\n\n"),
             "brief" | "short" => String::new(),
             "code" => {
-                let lang = params.get(0).map(|p| p.as_str()).unwrap_or_default();
+                let lang = params.first().map(|p| p.as_str()).unwrap_or_default();
                 let lang = lang.strip_prefix('.').unwrap_or(lang);
                 format!("```{lang}")
             }

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -3,8 +3,20 @@ pub(crate) enum LexItem {
     At(String),
     Paren(char),
     Word(String),
-    Space,
+    Whitespace(char),
     NewLine,
+}
+
+impl LexItem {
+    pub(crate) fn push_to(&self, acc: &mut String) {
+        match self {
+            LexItem::At(s) => acc.push_str(s),
+            LexItem::Paren(c) => acc.push(*c),
+            LexItem::Word(s) => acc.push_str(s),
+            LexItem::Whitespace(c) => acc.push(*c),
+            LexItem::NewLine => acc.push('\n'),
+        }
+    }
 }
 
 pub(crate) fn lex(input: String) -> Vec<LexItem> {
@@ -34,12 +46,8 @@ pub(crate) fn lex(input: String) -> Vec<LexItem> {
             '{' | '}' => {
                 result.push(LexItem::Paren(c));
             }
-            ' ' => {
-                if let Some(v) = result.last_mut() {
-                    if !matches!(v, LexItem::Space) {
-                        result.push(LexItem::Space);
-                    }
-                }
+            ' ' | '\t' => {
+                result.push(LexItem::Whitespace(c));
             }
             '\n' => {
                 result.push(LexItem::NewLine);
@@ -72,9 +80,9 @@ mod test {
             vec![
                 LexItem::At("@".into()),
                 LexItem::Word("name".into()),
-                LexItem::Space,
+                LexItem::Whitespace(' '),
                 LexItem::Word("Memory".into()),
-                LexItem::Space,
+                LexItem::Whitespace(' '),
                 LexItem::Word("Management".into())
             ]
         );
@@ -85,9 +93,9 @@ mod test {
             vec![
                 LexItem::At("\\".into()),
                 LexItem::Word("name".into()),
-                LexItem::Space,
+                LexItem::Whitespace(' '),
                 LexItem::Word("Memory".into()),
-                LexItem::Space,
+                LexItem::Whitespace(' '),
                 LexItem::Word("Management".into())
             ]
         );
@@ -98,9 +106,9 @@ mod test {
             vec![
                 LexItem::At("\\\\".into()),
                 LexItem::Word("name".into()),
-                LexItem::Space,
+                LexItem::Whitespace(' '),
                 LexItem::Word("Memory".into()),
-                LexItem::Space,
+                LexItem::Whitespace(' '),
                 LexItem::Word("Management".into())
             ]
         );
@@ -116,12 +124,12 @@ mod test {
                 LexItem::Paren('{'),
                 LexItem::NewLine,
                 LexItem::Word("*".into()),
-                LexItem::Space,
+                LexItem::Whitespace(' '),
                 LexItem::At("@".into()),
                 LexItem::Word("name".into()),
-                LexItem::Space,
+                LexItem::Whitespace(' '),
                 LexItem::Word("Memory".into()),
-                LexItem::Space,
+                LexItem::Whitespace(' '),
                 LexItem::Word("Management".into()),
                 LexItem::NewLine,
                 LexItem::At("@".into()),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -131,8 +131,7 @@ fn parse_items(input: Vec<LexItem>) -> Result<Vec<GrammarItem>, ParseError> {
                                     .iter()
                                     .enumerate()
                                     .skip(2)
-                                    .skip_while(|(_, next)| matches!(next, LexItem::Whitespace(_)))
-                                    .next()
+                                    .find(|(_, next)| !matches!(next, LexItem::Whitespace(_)))
                                     .and_then(|(skip, next)| match next {
                                         LexItem::Word(word) => Some((skip, word)),
                                         _ => None,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -157,6 +157,10 @@ fn parse_items(input: Vec<LexItem>) -> Result<Vec<GrammarItem>, ParseError> {
                                 params,
                                 tag: content.into(),
                             });
+
+                            if content == "endcode" {
+                                grammar_items.push(GrammarItem::Text("".into()));
+                            }
                         }
                         _ => {}
                     }
@@ -330,6 +334,7 @@ mod test {
                     params: vec![],
                     tag: "endcode".into(),
                 },
+                GrammarItem::Text("".into())
             ]
         )
     }
@@ -352,6 +357,36 @@ mod test {
                     params: vec![],
                     tag: "endcode".into(),
                 },
+                GrammarItem::Text("".into())
+            ]
+        )
+    }
+
+    #[test]
+    pub fn code_with_args() {
+        let result = parse("@code\nfn main() {}\n@endcode\n\n@param[in] a - a".into()).unwrap();
+
+        assert_eq!(
+            result,
+            vec![
+                GrammarItem::Notation {
+                    meta: vec![],
+                    params: vec![],
+                    tag: "code".into(),
+                },
+                GrammarItem::Text("\nfn main() {}\n".into()),
+                GrammarItem::Notation {
+                    meta: vec![],
+                    params: vec![],
+                    tag: "endcode".into(),
+                },
+                GrammarItem::Text("\n\n".into()),
+                GrammarItem::Notation {
+                    meta: vec!["in".into()],
+                    params: vec!["a".into()],
+                    tag: "param".into()
+                },
+                GrammarItem::Text(" - a".into())
             ]
         )
     }


### PR DESCRIPTION
Adds support for doxygen [code commands](https://www.doxygen.nl/manual/commands.html#cmdcode)

Notable changes:

- Added `\t` char as a possible whitespace
- Whitespaces used to be collapsed in the lexer. Since code blocks should retain all formatting, lexer emits `Whitespace` items for every whitespace instead. Now they are collapsed in the parser, which checks if the last `GrammarItem` ends with a whitespace
- `@code` can optionally have an additional parameter (lang) passed with brackets as in `@code{.py}`. For that, I changed the parameter parsing logic to parse parameters separated with whitespace (including multiple whitespace lexemes)  and inside of the brackets.